### PR TITLE
#32: Add dockerfile for creating posgres container with all CSV data loaded.

### DIFF
--- a/CreateDB.sql
+++ b/CreateDB.sql
@@ -1,0 +1,3 @@
+CREATE TABLE budget_data (state char(2),county varchar(50), year int,item varchar(100), budget int, source varchar(150));
+
+COPY budget_data(state, county, year, item, budget, source) FROM '/tmp/allbudgets.csv' DELIMITER ',' CSV HEADER;

--- a/PostgresDockerfile
+++ b/PostgresDockerfile
@@ -1,0 +1,23 @@
+FROM postgres:9.3
+
+# Need dos2unix since some CSVs have inconsistent line endings.
+RUN apt update && apt install -y dos2unix
+
+RUN mkdir /data
+RUN mkdir /data/states
+ADD ./data/ /tmp
+
+# create 1 csv with all other CSV data
+RUN touch /tmp/allbudgets.csv
+RUN echo "state,county,year,item,budget,source" >> /tmp/allbudgets.csv
+RUN for file in /tmp/states/*/*/*.csv;  do  dos2unix $file; sed -i -e '$a\' $file; tail -n +2 $file >> /tmp/allbudgets.csv; done
+
+
+# Set Postgres ENV variables
+ENV POSTGRES_USER docker
+ENV POSTGRES_PASSWORD docker
+ENV POSTGRES_DB docker
+
+# Create Table and Load CSV Data
+ADD CreateDB.sql /docker-entrypoint-initdb.d/
+


### PR DESCRIPTION
## Description

Addresses #32 

Added a short Dockerfile that uses the Postgres docker image to initialize a table, "budget_data", with all CSV data in `/data/states`. Included CreateDB.sql, which contains the SQL commands to run on initializing the Postgres daemon.

## How to use it

1. `docker build -t "db:PostgresDockerfile" . -f PostgresDockerfile` 
2. `docker run -d db:PostgresDockerfile` # this will output a hash for the running container
3. `docker exec -it $HASH psql -U docker` # use the hash output from command 2
4. Now that you are in Postgres as user docker, run `select * from "budget_data";`. The quotes are important.

## Organization

I have these files currently at the top level directory of this project, but if that causes too much clutter, we can find a different place for them.
