### PR TITLE
Added 2021 data for Greenville, SC

### DIFF
--- a/data/states/South Carolina/Greenville/budget.csv
+++ b/data/states/South Carolina/Greenville/budget.csv
@@ -40,3 +40,46 @@ SC,Greenville,2020,Outside Agencies,4337648,https://www.greenvillecounty.org/Man
 SC,Greenville,2020,Matching Funds/Grants,200000,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
 SC,Greenville,2020,Other Financing Uses/Debt Service,3072791,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
 SC,Greenville,2020,Other Financing Uses/Internal Services,5000000,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,County Council,1210881.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Council Administrator,881443.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,County Attorney,1008648.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Financial Operations,1615318.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Geographic Information Systems,684614.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Information Systems and Services,6047964.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Procurement Services,500183.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Tax Services,4082276.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Board of Appeals,9000.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Human Relations,181569.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Human Resources,1123533.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Registration and Election,1135957.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Veterans Affairs,387960.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Animal Care Services,4980755.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Code Enforcement,3674064.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Planning,1233324.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Public Works Administrator,505278.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Engineering,6104910.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Property Management,6661744.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Detention Center,23896610.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Forensics,2997242.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Indigent Defense,219721.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Records,2649849.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Circuit Solicitor,7597073.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Clerk of Court,3925023.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Master in Equity,606455.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Magistrates,5556005.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Probate Court,1872383.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Public Defender,1239331.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Auditor,1364609.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Register of Deeds,1323643.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Treasurer,499818.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Coroner,1350563.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Medical Examienr,734810.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Sheriff,48847781.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Employee Benefit Fund,6819595.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Legislative Delegation,67709.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Non-Departmenatl,4600535.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Outside Agencies,4837648.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Matching Funds/Grants,200000.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Other Financing Uses/Debt Service,3258518.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+SC,Greenville,2021,Other Financing Uses/Internal Services,5000000.00,https://www.greenvillecounty.org/ManagementAndBudget/pdf/2019/GeneralFund.pdf
+


### PR DESCRIPTION
Latest data for 2021. I placed it below the 2020 data in the budget.csv file.