### PR TITLE
Fixed getdata route to return budget data for state/county

### DIFF
--- a/CreateDB.sql
+++ b/CreateDB.sql
@@ -1,3 +1,3 @@
-CREATE TABLE budget_data (state char(2),county varchar(50), year int,item varchar(100), budget int, source varchar(150));
+CREATE TABLE budget_data (id SERIAL PRIMARY KEY, state char(2),county varchar(50), year int,item varchar(100), budget int, source varchar(150));
 
 COPY budget_data(state, county, year, item, budget, source) FROM '/tmp/allbudgets.csv' DELIMITER ',' CSV HEADER;

--- a/api/budgetsdata.py
+++ b/api/budgetsdata.py
@@ -22,6 +22,7 @@ db = SQLAlchemy(application)
 
 
 class States(db.Model):
+    __tablename__ = 'budget_data'
     id = db.Column(db.Integer, primary_key=True)
     state = db.Column(db.String(50))
     county = db.Column(db.String(50))
@@ -112,20 +113,26 @@ def checkstates():
 @application.route("/getdata")
 def getdata():
     state = request.args.get("state")
+    if len(state) == 2:
+        state = state.upper()
+    else:
+        state = statereversemap(state)[0]
     county = request.args.get("county")
     data = States.query.filter(
-        States.state == statereversemap(state), States.county == county
-    )
+        States.state == state, States.county == county
+        ).all()
     responsedata = dict()
     responsedata["state"] = state
     responsedata["county"] = county
 
-    for i in data:
-        i_dict = i.__dict__
-        responsedata[i_dict["item"]] = i_dict["budget"]
+    if data:
+        for budget_row in data:
+            responsedata[budget_row.item] = budget_row.budget
 
-    responsedata["year"] = i_dict["year"]
-    responsedata["source"] = i_dict["source"]
+        responsedata["year"] = budget_row.year
+        responsedata["source"] = budget_row.source
+    else:
+        responsedata['error'] = f'Nothing returned for the state/county combination.'
 
     return responsedata
 

--- a/api/mapping.py
+++ b/api/mapping.py
@@ -9,9 +9,9 @@
 
 
 def statereversemap(state):
-    if state == "Virginia":
+    if state.lower() == "virginia":
         return ("VA",)
-    elif state == "Texas":
+    elif state.lower() == "texas":
         return ("TX",)
 
 


### PR DESCRIPTION
I also added some flexibility for the state parameter allowing a user to search regardless of the case of the state search term and assuming an abbreviation if the length of the state search parameter is 2 characters and assuming a full state name if the length is anything else.